### PR TITLE
Add normalizing of user user object in getClientInitializeResponse

### DIFF
--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -270,7 +270,8 @@ export default class StatsigServer {
         'statsigSDK::getClientInitializeResponse> Must call initialize() first.',
       );
     }
-    return this._evaluator.getClientInitializeResponse(user);
+    const normalizedUser = normalizeUser(user, this._options);
+    return this._evaluator.getClientInitializeResponse(normalizedUser);
   }
 
   public overrideGate(


### PR DESCRIPTION
The getClientInitializeResponse function of the statsig-node SDK actually doesn’t evaluate the environment tier value,  doing some debugging it was found that it isn't setting that value it is getting undefined when trying to evaluate it and by conclusion a false boolean in the result.

There is already a function called normalizeUser for setting the environment to the user so just using this one the problem can be solved. 

I hope this explanation can help to speed up a new release with the adjustment.

Currently:
StatsigServer.getClientInitializeResponse -> Evaluator.getClientInitializeResponse -> eval -> evalRule -> evalCondition -> getFromEnvironment -> undefined statsigEnvironment

Solution:
StatsigServer.getClientInitializeResponse -> normalizeUser -> Evaluator.getClientInitializeResponse -> eval -> evalRule -> evalCondition -> getFromEnvironment -> existing statsigEnvironment