### PR TITLE
Add statsigEnvironment field to StatsigUser type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module 'statsig-node' {
       string | number | boolean | Array<string> | undefined
     >;
     customIDs?: Record<string, string>;
+    statsigEnvironment?: StatsigEnvironment;
   };
 
   /**


### PR DESCRIPTION
The statsigEnvironment was missing in the type definition for the StatsigUser object