### PR TITLE
fix(typing): userID is required on StatsigUser

### DIFF
--- a/src/StatsigUser.ts
+++ b/src/StatsigUser.ts
@@ -1,7 +1,7 @@
 import { StatsigEnvironment } from './StatsigOptions';
 
 export type StatsigUser = {
-  userID?: string;
+  userID: string;
   email?: string;
   ip?: string;
   userAgent?: string;


### PR DESCRIPTION
If you do not supply a userID getting a dynamic config, you get a runtime error. This should be reflected in the StatsigUser type to enable static type checks for when userID is set to something that might be null or undefined.

This type is also listed as having userID required in [the docs](https://docs.statsig.com/server/nodejsServerSDK#type-statsiguser)