### PR TITLE
feat(flush): added retries and backoff as optional parameters to Statsig.flush

### DIFF
--- a/src/LogEventProcessor.ts
+++ b/src/LogEventProcessor.ts
@@ -77,7 +77,7 @@ export default class LogEventProcessor {
     }
   }
 
-  public async flush(fireAndForget = false): Promise<void> {
+  public async flush(fireAndForget = false, retries: number = 5, backoff: number = 10000): Promise<void> {
     if (this.queue.length === 0) {
       return Promise.resolve();
     }
@@ -88,7 +88,7 @@ export default class LogEventProcessor {
       events: oldQueue,
     };
     return this.fetcher
-      .post(this.options.api + '/log_event', body, fireAndForget ? 0 : 5, 10000)
+      .post(this.options.api + '/log_event', body, fireAndForget ? 0 : retries, backoff)
       .then(() => {
         return Promise.resolve();
       })

--- a/src/LogEventProcessor.ts
+++ b/src/LogEventProcessor.ts
@@ -15,6 +15,9 @@ const DIAGNOSTIC_EVENT = 'diagnostics';
 const INTERNAL_EVENT_PREFIX = 'statsig::';
 const DEFAULT_VALUE_WARNING = 'default_value_type_mismatch';
 
+export const DEFAULT_RETRIES = 5;
+export const DEFAULT_BACKOFF = 10000;
+
 const deduperInterval = 60 * 1000;
 
 const ignoredMetadataKeys = new Set([
@@ -77,7 +80,7 @@ export default class LogEventProcessor {
     }
   }
 
-  public async flush(fireAndForget = false, retries: number = 5, backoff: number = 10000): Promise<void> {
+  public async flush(fireAndForget = false, retries: number = DEFAULT_RETRIES, backoff: number = DEFAULT_BACKOFF): Promise<void> {
     if (this.queue.length === 0) {
       return Promise.resolve();
     }

--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -8,7 +8,7 @@ import {
 import Evaluator from './Evaluator';
 import Layer from './Layer';
 import LogEvent from './LogEvent';
-import LogEventProcessor from './LogEventProcessor';
+import LogEventProcessor, { DEFAULT_BACKOFF, DEFAULT_RETRIES } from './LogEventProcessor';
 import {
   ExplicitStatsigOptions,
   OptionsWithDefaults,
@@ -416,7 +416,7 @@ export default class StatsigServer {
     });
   }
 
-  public async flush(retries: number = 5, backoff: number = 10000): Promise<void> {
+  public async flush(retries: number = DEFAULT_RETRIES, backoff: number = DEFAULT_BACKOFF): Promise<void> {
     return this._errorBoundary.capture(
       () => {
         if (this._logger == null) {

--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -416,14 +416,14 @@ export default class StatsigServer {
     });
   }
 
-  public async flush(): Promise<void> {
+  public async flush(retries: number = 5, backoff: number = 10000): Promise<void> {
     return this._errorBoundary.capture(
       () => {
         if (this._logger == null) {
           return Promise.resolve();
         }
 
-        return this._logger.flush();
+        return this._logger.flush(retries === 0, retries, backoff);
       },
       () => Promise.resolve(),
     );


### PR DESCRIPTION
My team noticed some timeouts in our own company's endpoints that were caused by Statsig flushes taking too long. Our endpoints are serverless, so the flush needed to take place before we could send a response, which terminates the process. 10 seconds was way too long, but without a backoff parameter we were unable to do anything about it, or even disable retries if we wanted to. Our best alternative was using Promise.race to terminate if flushing was taking too long, but that seemed like a hack, and would still mean adding 10 seconds to our response times for a single retry. This is a non-breaking change that solves our problem, and will hopefully be useful for other Statsig users too. 