### PR TITLE
pass logger in but default to console.

### DIFF
--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -6,6 +6,7 @@ import {
 } from './Errors';
 import { getSDKType, getSDKVersion, getStatsigMetadata } from './utils/core';
 import safeFetch from './utils/safeFetch';
+import type { LoggerInterface } from './StatsigOptions';
 
 export const ExceptionEndpoint = 'https://statsigapi.net/v1/sdk_exception';
 
@@ -13,9 +14,11 @@ export default class ErrorBoundary {
   private sdkKey: string;
   private statsigMetadata = getStatsigMetadata();
   private seen = new Set<string>();
+  private logger: LoggerInterface;
 
-  constructor(sdkKey: string) {
+  constructor(sdkKey: string, logger: LoggerInterface) {
     this.sdkKey = sdkKey;
+    this.logger = logger;
   }
 
   swallow<T>(task: () => T) {
@@ -51,7 +54,7 @@ export default class ErrorBoundary {
       throw error; // Don't catch these
     }
 
-    console.error('[Statsig] An unexpected exception occurred.', error);
+    this.logger.error('[Statsig] An unexpected exception occurred.', error as Error);
 
     this.logError(error);
 

--- a/src/LogEvent.ts
+++ b/src/LogEvent.ts
@@ -10,21 +10,19 @@ export default class LogEvent {
   private value: string | number | null = null;
   private metadata: Record<string, unknown> | null = null;
   private secondaryExposures: Record<string, unknown>[] = [];
-  private logger: LoggerInterface;
 
   public constructor(eventName: string, logger: LoggerInterface) {
-    this.logger = logger;
     if (eventName == null || typeof eventName !== 'string') {
-      this.logger.error('statsigSDK> EventName needs to be a string.');
+      logger.error('statsigSDK> EventName needs to be a string.');
       eventName = 'invalid_event';
     }
     this.time = Date.now();
     this.eventName = eventName;
   }
 
-  public setUser(user: StatsigUser) {
+  public setUser(logger: LoggerInterface, user: StatsigUser) {
     if (user != null && typeof user !== 'object') {
-      this.logger.warn(
+      logger.warn(
         'statsigSDK> User is not set because it needs to be an object.',
       );
       return;
@@ -48,12 +46,12 @@ export default class LogEvent {
     }
   }
 
-  public setMetadata(metadata: Record<string, unknown> | null) {
+  public setMetadata(logger: LoggerInterface, metadata: Record<string, unknown> | null) {
     if (metadata == null) {
       return;
     }
     if (metadata != null && typeof metadata !== 'object') {
-      this.logger.warn(
+      logger.warn(
         'statsigSDK> Metadata is not set because it needs to be an object.',
       );
       return;
@@ -61,9 +59,9 @@ export default class LogEvent {
     this.metadata = clone(metadata);
   }
 
-  public setTime(time: number) {
+  public setTime(logger: LoggerInterface, time: number) {
     if (time != null && typeof time !== 'number') {
-      this.logger.warn(
+      logger.warn(
         'statsigSDK>Timestamp is not set because it needs to be a number.',
       );
       return;
@@ -77,6 +75,10 @@ export default class LogEvent {
 
   public validate(): boolean {
     return typeof this.eventName === 'string' && this.eventName.length > 0;
+  }
+
+  public toJSON(): Record<string, unknown> {
+    return this.toObject();
   }
 
   public toObject(): Record<string, unknown> {

--- a/src/LogEvent.ts
+++ b/src/LogEvent.ts
@@ -1,3 +1,4 @@
+import type { LoggerInterface } from './StatsigOptions';
 import { StatsigUser } from './StatsigUser';
 
 import { clone } from './utils/core';
@@ -9,10 +10,12 @@ export default class LogEvent {
   private value: string | number | null = null;
   private metadata: Record<string, unknown> | null = null;
   private secondaryExposures: Record<string, unknown>[] = [];
+  private logger: LoggerInterface;
 
-  public constructor(eventName: string) {
+  public constructor(eventName: string, logger: LoggerInterface) {
+    this.logger = logger;
     if (eventName == null || typeof eventName !== 'string') {
-      console.error('statsigSDK> EventName needs to be a string.');
+      this.logger.error('statsigSDK> EventName needs to be a string.');
       eventName = 'invalid_event';
     }
     this.time = Date.now();
@@ -21,7 +24,7 @@ export default class LogEvent {
 
   public setUser(user: StatsigUser) {
     if (user != null && typeof user !== 'object') {
-      console.warn(
+      this.logger.warn(
         'statsigSDK> User is not set because it needs to be an object.',
       );
       return;
@@ -50,7 +53,7 @@ export default class LogEvent {
       return;
     }
     if (metadata != null && typeof metadata !== 'object') {
-      console.warn(
+      this.logger.warn(
         'statsigSDK> Metadata is not set because it needs to be an object.',
       );
       return;
@@ -60,7 +63,7 @@ export default class LogEvent {
 
   public setTime(time: number) {
     if (time != null && typeof time !== 'number') {
-      console.warn(
+      this.logger.warn(
         'statsigSDK>Timestamp is not set because it needs to be a number.',
       );
       return;

--- a/src/LogEventProcessor.ts
+++ b/src/LogEventProcessor.ts
@@ -4,7 +4,7 @@ import Diagnostics, { Marker } from './Diagnostics';
 import { StatsigLocalModeNetworkError } from './Errors';
 import { EvaluationDetails } from './EvaluationDetails';
 import LogEvent from './LogEvent';
-import { ExplicitStatsigOptions } from './StatsigOptions';
+import { ExplicitStatsigOptions, LoggerInterface } from './StatsigOptions';
 import { StatsigUser } from './StatsigUser';
 import StatsigFetcher from './utils/StatsigFetcher';
 
@@ -27,6 +27,7 @@ const ignoredMetadataKeys = new Set([
 export default class LogEventProcessor {
   private options: ExplicitStatsigOptions;
   private fetcher: StatsigFetcher;
+  private logger: LoggerInterface;
 
   private queue: LogEvent[];
   private flushTimer: NodeJS.Timer | null;
@@ -38,6 +39,7 @@ export default class LogEventProcessor {
   public constructor(fetcher: StatsigFetcher, options: ExplicitStatsigOptions) {
     this.options = options;
     this.fetcher = fetcher;
+    this.logger = options.logger;
 
     this.queue = [];
     this.deduper = new Set();
@@ -125,7 +127,7 @@ export default class LogEventProcessor {
       return;
     }
 
-    const event = new LogEvent(INTERNAL_EVENT_PREFIX + eventName);
+    const event = new LogEvent(INTERNAL_EVENT_PREFIX + eventName, this.logger);
     if (user != null) {
       event.setUser(user);
     }

--- a/src/LogEventProcessor.ts
+++ b/src/LogEventProcessor.ts
@@ -129,11 +129,11 @@ export default class LogEventProcessor {
 
     const event = new LogEvent(INTERNAL_EVENT_PREFIX + eventName, this.logger);
     if (user != null) {
-      event.setUser(user);
+      event.setUser(this.logger, user);
     }
 
     if (metadata != null) {
-      event.setMetadata(metadata);
+      event.setMetadata(this.logger, metadata);
     }
 
     if (secondaryExposures != null) {

--- a/src/StatsigOptions.ts
+++ b/src/StatsigOptions.ts
@@ -18,11 +18,17 @@ export type StatsigEnvironment = {
 
 export type InitStrategy = 'await' | 'lazy' | 'none';
 
+export type LoggerInterface = {
+  warn(msg: string | Error): void;
+  error(msg: string | Error, err?: Error): void;
+}
+
 export type ExplicitStatsigOptions = {
   api: string;
   bootstrapValues: string | null;
   environment: StatsigEnvironment | null;
   rulesUpdatedCallback: RulesUpdatedCallback | null;
+  logger: LoggerInterface;
   localMode: boolean;
   initTimeoutMs: number;
   dataAdapter: IDataAdapter | null;
@@ -54,6 +60,7 @@ export function OptionsWithDefaults(
       : null,
     localMode: getBoolean(opts, 'localMode', false),
     initTimeoutMs: getNumber(opts, 'initTimeoutMs', 0),
+    logger: opts.logger || console,
     dataAdapter: opts.dataAdapter ?? null,
     rulesetsSyncIntervalMs: Math.max(
       getNumber(opts, 'rulesetsSyncIntervalMs', DEFAULT_RULESETS_SYNC_INTERVAL),

--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -44,7 +44,7 @@ export type LogEventObject = {
 };
 
 /**
- * The global statsig class for interacting with gates, configs, experiments configured in the statsig developer this._logger.  Also used for event logging to view in the statsig this._logger, or for analyzing experiment impacts using pulse.
+ * The global statsig class for interacting with gates, configs, experiments configured in the statsig developer this._logger.  Also used for event logging to view in the Statsig console, or for analyzing experiment impacts using pulse.
  */
 export default class StatsigServer {
   private _pendingInitPromise: Promise<void> | null = null;
@@ -101,7 +101,7 @@ export default class StatsigServer {
         ) {
           return Promise.reject(
             new StatsigInvalidArgumentError(
-              'Invalid key provided.  You must use a Server Secret Key from the Statsig this._logger with the node-js-server-sdk',
+              'Invalid key provided.  You must use a Server Secret Key from the Statsig console with the node-js-server-sdk',
             ),
           );
         }
@@ -154,7 +154,7 @@ export default class StatsigServer {
   }
 
   /**
-   * Check the value of a gate configured in the statsig this._logger
+   * Check the value of a gate configured in the Statsig console
    * @throws Error if initialize() was not called first
    * @throws Error if the gateName is not provided or not a non-empty string
    */

--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -390,12 +390,12 @@ export default class StatsigServer {
       }
 
       let event = new LogEvent(eventName, this._logger);
-      event.setUser(user);
+      event.setUser(this._logger, user);
       event.setValue(value);
-      event.setMetadata(metadata);
+      event.setMetadata(this._logger, metadata);
 
       if (typeof time === 'number') {
-        event.setTime(time);
+        event.setTime(this._logger, time);
       }
 
       this._logProcessor.log(event);

--- a/src/__tests__/ErrorBoundary.test.ts
+++ b/src/__tests__/ErrorBoundary.test.ts
@@ -12,7 +12,7 @@ describe('ErrorBoundary', () => {
   let requests: { url: RequestInfo; params: RequestInit }[] = [];
 
   beforeEach(() => {
-    boundary = new ErrorBoundary('secret-key');
+    boundary = new ErrorBoundary('secret-key', console);
     requests = [];
 
     const fetch = require('node-fetch');
@@ -64,7 +64,7 @@ describe('ErrorBoundary', () => {
 
     expect(requests[0].url).toEqual(ExceptionEndpoint);
 
-    expect(JSON.parse(requests[0].params.body.toString())).toEqual(
+    expect(JSON.parse(requests[0].params.body!.toString())).toEqual(
       expect.objectContaining({
         exception: 'URIError',
         info: err.stack,
@@ -79,7 +79,7 @@ describe('ErrorBoundary', () => {
     });
 
     expect(requests[0].url).toEqual(ExceptionEndpoint);
-    expect(JSON.parse(requests[0].params.body.toString())).toEqual(
+    expect(JSON.parse(requests[0].params.body!.toString())).toEqual(
       expect.objectContaining({
         exception: 'No Name',
         info: JSON.stringify(err),
@@ -109,7 +109,7 @@ describe('ErrorBoundary', () => {
       throw new Error();
     });
 
-    expect(JSON.parse(requests[0].params.body.toString())).toEqual(
+    expect(JSON.parse(requests[0].params.body!.toString())).toEqual(
       expect.objectContaining({
         statsigMetadata: getStatsigMetadata(),
       }),

--- a/src/__tests__/StatsigErrorBoundaryUsage.test.ts
+++ b/src/__tests__/StatsigErrorBoundaryUsage.test.ts
@@ -43,7 +43,7 @@ describe('Statsig ErrorBoundary Usage', () => {
       },
     };
     // @ts-ignore
-    statsig._logger = 1;
+    statsig._logProcessor = 1;
   });
 
   it('recovers from error and returns default gate value', async () => {

--- a/src/__tests__/StatsigErrorBoundaryUsage.test.ts
+++ b/src/__tests__/StatsigErrorBoundaryUsage.test.ts
@@ -84,17 +84,17 @@ describe('Statsig ErrorBoundary Usage', () => {
 
   it('recovers from error with logEvent', () => {
     statsig.logEvent(user, 'an_event');
-    expect(requests).toEqual(oneLoggedError('_logger.log'));
+    expect(requests).toEqual(oneLoggedError('_logProcessor.log'));
   });
 
   it('recovers from error with logEventObject', () => {
     statsig.logEventObject({ user, eventName: 'an_event' });
-    expect(requests).toEqual(oneLoggedError('_logger.log'));
+    expect(requests).toEqual(oneLoggedError('_logProcessor.log'));
   });
 
   it('recovers from error with shutdown', () => {
     statsig.shutdown();
-    expect(requests).toEqual(oneLoggedError('_logger.shutdown'));
+    expect(requests).toEqual(oneLoggedError('_logProcessor.shutdown'));
   });
 
   it('recovers from error with overrideGate', () => {
@@ -109,7 +109,7 @@ describe('Statsig ErrorBoundary Usage', () => {
 
   it('recovers from error with overrideConfig', async () => {
     await statsig.flush();
-    expect(requests).toEqual(oneLoggedError('_logger.flush'));
+    expect(requests).toEqual(oneLoggedError('_logProcessor.flush'));
   });
 
   it('recovers from error with initialize', async () => {

--- a/src/__tests__/StatsigTestUtils.ts
+++ b/src/__tests__/StatsigTestUtils.ts
@@ -11,7 +11,7 @@ export default abstract class StatsigTestUtils {
 
   static getLogger(): any {
     // @ts-ignore
-    return StatsigInstanceUtils.getInstance()?._logger ?? null;
+    return StatsigInstanceUtils.getInstance()?._logProcessor ?? null;
   }
 }
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -350,11 +350,11 @@ describe('Verify behavior of top level index functions', () => {
     let gateName = 'gate_pass';
 
     const spy = jest.spyOn(StatsigTestUtils.getLogger(), 'log');
-    const gateExposure = new LogEvent('statsig::gate_exposure');
-    gateExposure.setUser({
+    const gateExposure = new LogEvent('statsig::gate_exposure', console);
+    gateExposure.setUser(console, {
       userID: '123',
     });
-    gateExposure.setMetadata({
+    gateExposure.setMetadata(console, {
       gate: gateName,
       gateValue: String(true),
       ruleID: 'rule_id_pass',
@@ -396,13 +396,13 @@ describe('Verify behavior of top level index functions', () => {
     let gateName = 'gate_fail';
 
     const spy = jest.spyOn(StatsigTestUtils.getLogger(), 'log');
-    const gateExposure = new LogEvent('statsig::gate_exposure');
-    gateExposure.setUser({
+    const gateExposure = new LogEvent('statsig::gate_exposure', console);
+    gateExposure.setUser(console, {
       userID: '123',
       // @ts-ignore
       statsigEnvironment: { tier: 'production' },
     });
-    gateExposure.setMetadata({
+    gateExposure.setMetadata(console, {
       gate: gateName,
       gateValue: String(false),
       ruleID: 'rule_id_fail',
@@ -467,11 +467,11 @@ describe('Verify behavior of top level index functions', () => {
     let configName = 'config_downloaded';
 
     const spy = jest.spyOn(StatsigTestUtils.getLogger(), 'log');
-    const configExposure = new LogEvent('statsig::config_exposure');
-    configExposure.setUser({
+    const configExposure = new LogEvent('statsig::config_exposure', console);
+    configExposure.setUser(console, {
       userID: '123',
     });
-    configExposure.setMetadata({
+    configExposure.setMetadata(console, {
       config: configName,
       ruleID: 'rule_id_config',
     });
@@ -635,9 +635,9 @@ describe('Verify behavior of top level index functions', () => {
       const spy = jest.spyOn(StatsigTestUtils.getLogger(), 'log');
       Statsig.logEvent({ userID: '123' }, 'test', 0);
 
-      const logEvent = new LogEvent('test');
-      logEvent.setMetadata(null);
-      logEvent.setUser({ userID: '123' });
+      const logEvent = new LogEvent('test', console);
+      logEvent.setMetadata(console, null);
+      logEvent.setUser(console, { userID: '123' });
       logEvent.setValue(0);
       expect(spy).toBeCalledWith(logEvent);
       expect(logEvent.toObject().value).toEqual(0);
@@ -651,9 +651,9 @@ describe('Verify behavior of top level index functions', () => {
       const spy = jest.spyOn(StatsigTestUtils.getLogger(), 'log');
       Statsig.logEvent({ userID: '123' }, 'test', '');
 
-      const logEvent = new LogEvent('test');
-      logEvent.setMetadata(null);
-      logEvent.setUser({ userID: '123' });
+      const logEvent = new LogEvent('test', console);
+      logEvent.setMetadata(console, null);
+      logEvent.setUser(console, { userID: '123' });
       logEvent.setValue('');
       expect(spy).toBeCalledWith(logEvent);
       expect(logEvent.toObject().value).toEqual('');
@@ -670,11 +670,11 @@ describe('Verify behavior of top level index functions', () => {
         user: { userID: '123', privateAttributes: { secret: 'do not log' } },
       });
 
-      const logEvent = new LogEvent('event');
-      logEvent.setMetadata(null);
-      logEvent.setUser({ userID: '123' });
+      const logEvent = new LogEvent('event', console);
+      logEvent.setMetadata(console, null);
+      logEvent.setUser(console, { userID: '123' });
       logEvent.setValue(null);
-      logEvent.setTime(123);
+      logEvent.setTime(console, 123);
       expect(spy).toBeCalledWith(logEvent);
     });
   });
@@ -728,8 +728,8 @@ describe('Verify behavior of top level index functions', () => {
         extradata: str_1k,
       });
 
-      const trimmedEvent = new LogEvent(str_64.substring(0, 64));
-      trimmedEvent.setUser({
+      const trimmedEvent = new LogEvent(str_64.substring(0, 64), console);
+      trimmedEvent.setUser(console, {
         userID: str_64,
         email: 'jest@Statsig.com',
         custom: {
@@ -737,7 +737,7 @@ describe('Verify behavior of top level index functions', () => {
         },
       });
       trimmedEvent.setValue(str_64.substring(0, 64));
-      trimmedEvent.setMetadata({ statsig_error: 'Metadata length too large' });
+      trimmedEvent.setMetadata(console, { statsig_error: 'Metadata length too large' });
       expect(spy).toBeCalledWith(trimmedEvent);
     });
   });


### PR DESCRIPTION
This adds a new option to overwrite the logger away from `console`.

I passed the loggerinterface around everywhere and fixed tests.