### PR TITLE
Patch sync interval reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-node",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-node",
-      "version": "5.8.2",
+      "version": "5.8.3",
       "license": "ISC",
       "dependencies": {
         "ip3country": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-node",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "description": "Statsig Node.js SDK for usage in multi-user server environments.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/SpecStore.ts
+++ b/src/SpecStore.ts
@@ -223,14 +223,12 @@ export default class SpecStore {
     let message = '';
     if (syncTimerInactive) {
       this.clearSyncTimer();
-      this._syncValues();
       message = message.concat(`Force reset sync timer. Last update time: ${
         this.syncTimerLastActiveTime
       }, now: ${Date.now()}`);
     }
     if (idListsSyncTimerInactive) {
       this.clearIdListsSyncTimer();
-      this._syncIdLists();
       message = message.concat(`Force reset id list sync timer. Last update time: ${
         this.idListsSyncTimerLastActiveTime
       }, now: ${Date.now()}`);
@@ -299,6 +297,7 @@ export default class SpecStore {
 
   private pollForUpdates() {
     if (this.syncTimer == null) {
+      this.syncTimerLastActiveTime = Date.now();
       this.syncTimer = poll(async () => {
         this.syncTimerLastActiveTime = Date.now();
         await this._syncValues();
@@ -306,6 +305,7 @@ export default class SpecStore {
     }
 
     if (this.idListsSyncTimer == null) {
+      this.idListsSyncTimerLastActiveTime = Date.now();
       this.idListsSyncTimer = poll(async () => {
         this.idListsSyncTimerLastActiveTime = Date.now();
         await this._syncIdLists();

--- a/src/__tests__/ResetSync.test.ts
+++ b/src/__tests__/ResetSync.test.ts
@@ -88,6 +88,18 @@ describe('Verify sync intervals reset', () => {
       { userID: '123', email: 'tore@packers.com' },
       'nfl_gate',
     );
+    gate = await statsig.checkGate(
+      { userID: '123', email: 'tore@packers.com' },
+      'nfl_gate',
+    );
+    gate = await statsig.checkGate(
+      { userID: '123', email: 'tore@packers.com' },
+      'nfl_gate',
+    );
+    gate = await statsig.checkGate(
+      { userID: '123', email: 'tore@packers.com' },
+      'nfl_gate',
+    );
     expect(gate).toBe(true);
     expect(spy).toHaveBeenCalledTimes(1);
   });

--- a/src/utils/StatsigFetcher.ts
+++ b/src/utils/StatsigFetcher.ts
@@ -56,7 +56,7 @@ export default class StatsigFetcher {
     if (counter != null && counter >= 1000) {
       return Promise.reject(
         new StatsigTooManyRequestsError(
-          'Request failed because you are making the same request too frequently.',
+          `Request to ${url} failed because you are making the same request too frequently (${counter}).`,
         ),
       );
     }


### PR DESCRIPTION
Patches a bug where the sdk failing to fetch config specs or id lists from the network could cause every gate or experiment check to spawn a (non blocking) network request to statsig servers to force sync

This bug was introduced in 5.8.2