### PR TITLE
Example of AbortSignal for the flush api

### DIFF
--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -415,14 +415,14 @@ export default class StatsigServer {
     );
   }
 
-  public async flush(): Promise<void> {
+  public async flush(signal?: AbortSignal): Promise<void> {
     return this._errorBoundary.capture(
       () => {
         if (this._logger == null) {
           return Promise.resolve();
         }
 
-        return this._logger.flush();
+        return this._logger.flush(false, signal);
       },
       () => Promise.resolve(),
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,12 +363,12 @@ export const Statsig = {
   /**
    * Flushes all the events that are currently in the queue to Statsig.
    */
-  flush(): Promise<void> {
+  flush(signal?: AbortSignal): Promise<void> {
     const inst = StatsigInstanceUtils.getInstance();
     if (inst == null) {
       return Promise.resolve();
     }
-    return inst.flush();
+    return inst.flush(signal);
   },
 
   /**

--- a/src/utils/StatsigFetcher.ts
+++ b/src/utils/StatsigFetcher.ts
@@ -16,6 +16,7 @@ type RequestOptions = Partial<{
   retries: number;
   backoff: number | RetryBackoffFunc;
   isRetrying: boolean;
+  signal?: AbortSignal;
 }>;
 
 export default class StatsigFetcher {
@@ -115,6 +116,7 @@ export default class StatsigFetcher {
         'STATSIG-SDK-TYPE': getSDKType(),
         'STATSIG-SDK-VERSION': getSDKVersion(),
       },
+      signal: options?.signal,
     };
 
     if (!isRetrying) {


### PR DESCRIPTION
This is an example PR for a Slack conversation about allowing to abort the Statsig flush api via an AbortSignal provided by the user of the package.