### PR TITLE
v5.12.1 - Disable logevent compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-node",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-node",
-      "version": "5.12.0",
+      "version": "5.12.1",
       "license": "ISC",
       "dependencies": {
         "ip3country": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-node",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "description": "Statsig Node.js SDK for usage in multi-user server environments.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
log event compression would cause log events to be dropped in edge/cloud function environments