### PR TITLE
Add clearAll Gate, Config, Layer overrides methods

### DIFF
--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -107,6 +107,18 @@ export default class Evaluator {
     this.layerOverrides[layerName] = overrides;
   }
 
+  public clearAllGateOverrides(): void {
+    this.gateOverrides = {};
+  }
+
+  public clearAllConfigOverrides(): void {
+    this.configOverrides = {};
+  }
+
+  public clearAllLayerOverrides(): void {
+    this.layerOverrides = {};
+  }
+
   public checkGate(user: StatsigUser, gateName: string): ConfigEvaluation {
     const override = this.lookupGateOverride(user, gateName);
     if (override) {

--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -574,6 +574,18 @@ export default class StatsigServer {
     );
   }
 
+  public clearAllGateOverrides(): void {
+    this._evaluator.clearAllGateOverrides();
+  }
+
+  public clearAllConfigOverrides(): void {
+    this._evaluator.clearAllConfigOverrides();
+  }
+
+  public clearAllLayerOverrides(): void {
+    this._evaluator.clearAllLayerOverrides();
+  }
+
   public getFeatureGateList(): string[] {
     return this._evaluator.getFeatureGateList();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,14 +371,23 @@ export const Statsig = {
     this._enforceServer().overrideLayer(layerName, value, userID);
   },
 
+  /**
+   * Clears all gate overrides
+   */
   clearAllGateOverrides(): void {
     this._enforceServer().clearAllGateOverrides();
   },
 
+  /**
+   * Clears all config overrides
+   */
   clearAllConfigOverrides(): void {
     this._enforceServer().clearAllConfigOverrides();
   },
 
+  /**
+   * Clears all layer overrides
+   */
   clearAllLayerOverrides(): void {
     this._enforceServer().clearAllLayerOverrides();
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,6 +371,18 @@ export const Statsig = {
     this._enforceServer().overrideLayer(layerName, value, userID);
   },
 
+  clearAllGateOverrides(): void {
+    this._enforceServer().clearAllGateOverrides();
+  },
+
+  clearAllConfigOverrides(): void {
+    this._enforceServer().clearAllConfigOverrides();
+  },
+
+  clearAllLayerOverrides(): void {
+    this._enforceServer().clearAllLayerOverrides();
+  },
+
   /**
    * Flushes all the events that are currently in the queue to Statsig.
    */


### PR DESCRIPTION
Introduces 3 new methods to the top level `StatsigServer` class, each of which calls into the `Evaluator` to set its respective backing object to an empty object:
- `clearAllGateOverrides`
- `clearAllConfigOverrides`
- `clearAllLayerOverrides`

Please let me know if different naming would help or if there is associated documentation/tests that should be updated.


Resolves statsig-io/node-js-server-sdk#41

