### PR TITLE
Create .npmignore to keep prevent shipping useless code to node_modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+**/__tests__
+**/*.test.ts
+./.github/
+./.prettier*
+./docs/


### PR DESCRIPTION
This patch creates a `.npmignore` file and configures it to prevent various files and directories from being included the the module when it is consumed by applications.