### PR TITLE
fix: flush with timeout not respected by retries

### DIFF
--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -531,7 +531,7 @@ export default class StatsigServer {
           const controller = new AbortController();
           const handle = setTimeout(() => controller.abort(), timeout);
           flushPromise = this._logger
-            .flush(false, controller.signal)
+            .flush(true, controller.signal)
             .then(() => clearTimeout(handle));
         } else {
           flushPromise = this._logger.flush(false);


### PR DESCRIPTION
This method should best effort post and finish within the given timeout

This is how we call it in shutdown:

https://github.com/statsig-io/node-js-server-sdk/blob/main/src/LogEventProcessor.ts#L154

Which should remove retries