### PR TITLE
Shortcut hash computation for constant rules

### DIFF
--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -826,6 +826,12 @@ export default class Evaluator {
   }
 
   _evalPassPercent(user: StatsigUser, rule: ConfigRule, config: ConfigSpec) {
+    if (rule.passPercentage === 0) {
+      return false;
+    }
+    if (rule.passPercentage === 100) {
+      return true;
+    }
     const hash = computeUserHash(
       config.salt +
         '.' +


### PR DESCRIPTION
I noticed that this implementation is always computing the per-rule hash. Most targetting cases are either including or excluding all users which pass the condition.

Shortcutting these always pass / always fail cases will substantially reduce the number of string concatenation and hashing operations performed in this hot loop of rule evaluation.

Some other clients already have this optimisation:
https://github.com/statsig-io/js-client-monorepo/blob/main/packages/js-on-device-eval-client/src/Evaluator.ts#L427-L433

PR to do the same to the Java SDK: https://github.com/statsig-io/java-server-sdk/pull/28