### PR TITLE
feat(POC): pass overrides to getClientInitializeResponse

### DIFF
--- a/src/StatsigServer.ts
+++ b/src/StatsigServer.ts
@@ -67,6 +67,10 @@ export type LogEventObject = {
 export type ClientInitializeResponseOptions = {
   hash?: HashingAlgorithm;
   includeLocalOverrides?: boolean;
+  overrides?: {
+    gates?: Record<string, boolean>;
+    experimentsByGroupName?: Record<string, string>;
+  };
 };
 
 /**


### PR DESCRIPTION
Add a new feature to `getClientInitializeResponse`

This allows for an overrides object to be passed to `getClientInitializeResponse` so that evaluations can be overridden a a per request basis.

This solves our use case of being able to use query params in a url that loads a page that calls `getClientInitializeResponse` on the server side.

We can pass a query param like so
 example.com?override[my-exp-id]=Control&override[my-gate-id]=true

and then convert this into the object that is passed into the options for `getClientInitializeResponse`

We would like to use this to make testing easier to allow for a simple way to force a request into a bucket.
This also allows for the ability to share urls with non technical stakeholders and ensure they are bucketed correctly to see an experiment experience or a gate before it is turned on.


I haven't written tests yet as this is more a proof of concept to see if we can align on an interface for being able to do this


example of how this would be called

```
  const values = Statsig.getClientInitializeResponse(user, key, {
    hash: 'djb2',
    overrides: {
      gates: {
        'my-gate-id': true,
      },
      experimentsByGroupName: {
        'my-exp-id': 'Control',
      }
    }
  });
```